### PR TITLE
Fix DID format for profiles

### DIFF
--- a/app/(home)/(posts)/post/[slug]/page.tsx
+++ b/app/(home)/(posts)/post/[slug]/page.tsx
@@ -14,6 +14,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
+import { useAccount, useAccountEffect } from "wagmi";
 
 const CONTEXT_ID = env.NEXT_PUBLIC_CONTEXT_ID ?? "";
 const COMMENT_ID = env.NEXT_PUBLIC_COMMENT_ID ?? "";

--- a/app/context/OrbisContext.tsx
+++ b/app/context/OrbisContext.tsx
@@ -84,8 +84,8 @@ export const ODB = ({ children }: OrbisDBProps) => {
 
         if (
           sessionAddress !== walletClient.account.address.toLowerCase() ||
-          //@ts-ignore
-          expTime > Date.now()
+          expTime === undefined ||
+          Date.parse(expTime) < Date.now()
         ) {
           console.log("Invalid session, removing...");
           localStorage.removeItem("orbis:session");

--- a/app/context/OrbisContext.tsx
+++ b/app/context/OrbisContext.tsx
@@ -84,7 +84,7 @@ export const ODB = ({ children }: OrbisDBProps) => {
 
         if (
           sessionAddress !== walletClient.account.address.toLowerCase() ||
-          expTime === undefined ||
+         ( expTime !== undefined &&
           Date.parse(expTime) < Date.now()
         ) {
           console.log("Invalid session, removing...");

--- a/components/sections/home-modules.tsx
+++ b/components/sections/home-modules.tsx
@@ -9,7 +9,6 @@ import { env } from "@/env.mjs";
 import { Button } from "@/components/ui/button";
 import MaxWidthWrapper from "@/components/shared/max-width-wrapper";
 import { useODB } from "@/app/context/OrbisContext";
-import { set } from "zod";
 
 const PROFILE_ID = env.NEXT_PUBLIC_PROFILE_ID ?? "";
 const CONTEXT_ID = env.NEXT_PUBLIC_CONTEXT_ID ?? "";
@@ -26,7 +25,7 @@ export function HomeModules() {
         const profile = orbis
           .select("name", "username", "profile_imageid", "description")
           .from(PROFILE_ID)
-          .where({ controller: user.user.did.toLowerCase() })
+          .where({ controller: user.user.did })
           .context(CONTEXT_ID);
         const profileResult = await profile.run();
         if (profileResult.rows.length) {

--- a/components/sections/newPost-modules.tsx
+++ b/components/sections/newPost-modules.tsx
@@ -46,7 +46,7 @@ export function PostModules() {
         const profile = orbis
           .select("name", "username", "imageid", "description")
           .from(PROFILE_ID)
-          .where({ controller: user.user.did.toLowerCase() })
+          .where({ controller: user.user.did })
           .context(CONTEXT_ID);
         const profileResult = await profile.run();
         if (profileResult.rows.length) {

--- a/components/sections/profile-modules.tsx
+++ b/components/sections/profile-modules.tsx
@@ -10,7 +10,6 @@ import { type Profile } from "@/types/index";
 import { Button } from "@/components/ui/button";
 import MaxWidthWrapper from "@/components/shared/max-width-wrapper";
 import { useODB } from "@/app/context/OrbisContext";
-import { set } from "zod";
 
 const PROFILE_ID = env.NEXT_PUBLIC_PROFILE_ID ?? "";
 const CONTEXT_ID = env.NEXT_PUBLIC_CONTEXT_ID ?? "";
@@ -93,7 +92,7 @@ export function ProfileModules() {
         const profile = orbis
           .select("name", "username", "profile_imageid", "description")
           .from(PROFILE_ID)
-          .where({ controller: user.user.did.toLowerCase() })
+          .where({ controller: user.user.did })
           .context(CONTEXT_ID);
         const profileResult = await profile.run();
         console.log(profileResult);


### PR DESCRIPTION
Profile DID is stored at orbisDB using the ethereum address format (uppercase + lowercase). We were transforming it here to lowercase, so the profile was not been able to be retrieved.

Also, these changes fix expiration time check. The related `useEffect` checks if the session has expired and creates a new one if that's the case. But here we were comparing a string containing the UNIX timestamp with a string containing a date in human-readable format.

This caused that the session was not being renewed when it was expired.