### PR TITLE
Fix 2h TACo auth expiration time on SIWE

### DIFF
--- a/app/context/OrbisContext.tsx
+++ b/app/context/OrbisContext.tsx
@@ -11,6 +11,7 @@ import { OrbisDB, type OrbisConnectResult } from "@useorbis/db-sdk";
 import { OrbisEVMAuth } from "@useorbis/db-sdk/auth";
 import { useWalletClient, useAccountEffect } from "wagmi";
 import { env } from "@/env.mjs";
+import { FRESHNESS_IN_MILLISECONDS as TACO_EXPIRATION_TIME } from "@nucypher/taco-auth";
 
 type OrbisDBProps = {
   children: ReactNode;
@@ -86,7 +87,7 @@ export const ODB = ({ children }: OrbisDBProps) => {
         if (
           sessionAddress !== walletClient.account.address.toLowerCase() ||
           (expTime !== undefined && Date.parse(expTime) < Date.now()) ||
-          issuedAt < Date.now() - 2 * 60 * 60 * 1000
+          issuedAt < Date.now() - TACO_EXPIRATION_TIME
         ) {
           console.log("Invalid session, removing...");
           localStorage.removeItem("orbis:session");

--- a/app/context/OrbisContext.tsx
+++ b/app/context/OrbisContext.tsx
@@ -77,6 +77,7 @@ export const ODB = ({ children }: OrbisDBProps) => {
           Buffer.from(storedSession, "base64").toString(),
         ) as { cacao: Cacao };
 
+        const issuedAt = Date.parse(cacao.p.iat);
         const expTime = cacao.p.exp;
         const sessionAddress = cacao.p.iss
           .replace("did:pkh:eip155:1:", "")
@@ -84,8 +85,8 @@ export const ODB = ({ children }: OrbisDBProps) => {
 
         if (
           sessionAddress !== walletClient.account.address.toLowerCase() ||
-         ( expTime !== undefined &&
-          Date.parse(expTime) < Date.now()
+          (expTime !== undefined && Date.parse(expTime) < Date.now()) ||
+          issuedAt < Date.now() - 2 * 60 * 60 * 1000
         ) {
           console.log("Invalid session, removing...");
           localStorage.removeItem("orbis:session");


### PR DESCRIPTION
The maximum expiration time is not defined for SIWE standard, so it can be months (like in this case).

However, for TACo this expiration date is fixed to two hours after issuing the certificate.

So, when loading a SIWE session, this can be one that is still valid for SIWE standard, but not for TACo (more than 2h since it was issued).